### PR TITLE
Add a build step to ensure that the src directory is world-readable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ all:	dirs src/icu
 dirs:
 	mkdir -p $(DIRS) tmp/.ccache
 	chmod a+rwxt tmp/.ccache dist
+	chmod -R o+rX src
 
 dbuild: docker-compose.yml
 	docker-compose build


### PR DESCRIPTION
Docker will need all files within src to be world-readable (both bin
with the build scripts and icu with the source code).

If they're not, the build will fail with error messages like this:

env: '/src/bin//makesdoc.sh': Permission denied

Or like this:

/bin/bash: /src/icu/icu4c/source/configure: Permission denied