### PR TITLE
Add missing slash in command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It sets up `ccache` to share cached compiler output in `./tmp/.ccache` and expec
 
 this will make error messages work
 
-     sudo ln -sv `pwd`{src,dist} /
+     sudo ln -sv `pwd`/{src,dist} /
 
 - do some command line builds
 


### PR DESCRIPTION
Without this slash the base name of the current working directory will
be merged into the names of the symlinks being created, resulting in
them being named icu-dockerdist and icu-dockersrc (which is not what
they're supposed to be named).