### PR TITLE
Install rsync in ubuntu/Dockerfile.

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -10,7 +10,7 @@ RUN useradd -c "Build user" -d $HOME -m build
 
 # sanity and safety
 RUN apt-get -q -y update && apt-get -q -y upgrade
-RUN apt-get -q -y install make git subversion python ccache valgrind doxygen zip curl wget
+RUN apt-get -q -y install make git subversion python ccache valgrind doxygen zip curl wget rsync
 RUN apt-get -q -y install g++
 RUN mkdir /src /dist
 VOLUME /src


### PR DESCRIPTION
Without explicitly installing `rsync`, running `make dist` with a clean Docker installation (no pre-existing images) now fails like this:

```
mkdir dist/tmp
collecting excludes to /tmp/tmp.UWOPTwhMvB
(cd "/src/icu/icu4c/source/.." ; svn status --no-ignore  | grep '^I' | cut -c2- > "/tmp/tmp.UWOPTwhMvB" ) 
pseudo-exporting 41503
rsync -a --exclude-from="/tmp/tmp.UWOPTwhMvB" "/src/icu/icu4c/source/.." "dist/tmp/icu"
/bin/bash: rsync: command not found
/src/icu/icu4c/source/config/dist.mk:64: recipe for target '/home/build/dist/icu4c-src-62_1-r41503.tgz' failed
```
