### PR TITLE
workaround ICU not supporting git yet

### DIFF
--- a/src/bin/icu-git-rev.sh
+++ b/src/bin/icu-git-rev.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# © 2018 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+
+if ! command -v git > /dev/null 2>&1 ; then
+    echo 'git-not-installed'
+    exit 1
+fi
+
+DIR=${1:-/src/icu}
+cd ${DIR} >/dev/null || exit 1
+
+echo $(git rev-parse --short HEAD)
+exit 0

--- a/src/bin/makedist.sh
+++ b/src/bin/makedist.sh
@@ -8,13 +8,14 @@ if [ -f /etc/os-release ];
 then
     . /etc/os-release
 fi
-FN=icu-r${REV-$(svnversion /src/icu/ | tr -d ' ')}-$(bash /src/icu/icu4c/source/config.guess)-${NAME-${WHAT}}-${VERSION_ID-UNKNOWN}
+ICUREV=$(/src/bin/icu-git-rev.sh)
+FN=icu-r${REV-${ICUREV}}-$(bash /src/icu/icu4c/source/config.guess)-${NAME-${WHAT}}-${VERSION_ID-UNKNOWN}
 if [ ! -f config.status ];
 then
     icu-configure.sh || exit 1
 fi
 rm -rf /tmp/icu
-make -j${CORES} check && make -j${CORES} DESTDIR=/tmp/icu releaseDist || exit 1
+make -j${CORES} check && make -j${CORES} DESTDIR=/tmp/icu SVNVER=${ICUREV} releaseDist || exit 1
 #cp -v *-src-*.tgz /dist/${FN}-src.tgz || true
 cd /tmp/
 if [ -f /dist/${FN}.tgz ];

--- a/src/bin/makesdoc.sh
+++ b/src/bin/makesdoc.sh
@@ -9,21 +9,22 @@ if [ ! -f config.status ];
 then
     icu-configure.sh --disable-tests --disable-extras || exit 1
 fi
+ICUREV=$(/src/bin/icu-git-rev.sh)
 
 
 if [ -f /etc/os-release ];
 then
     . /etc/os-release
 fi
-FN=icu-r${REV-$(svnversion /src/icu/ | tr -d ' ')}-$(bash /src/icu/icu4c/source/config.guess)-${NAME-${WHAT}}-${VERSION_ID-UNKNOWN}
+FN=icu-r${ICUREV}-$(bash /src/icu/icu4c/source/config.guess)-${NAME-${WHAT}}-${VERSION_ID-UNKNOWN}
 
 rm -rf dist /dist/${FN}-src.d || true
-make -j${CORES} && make dist
+make -j${CORES} && make dist SVNVER=${ICUREV}
 
 mv -v dist /dist/${FN}-src.d
 
 rm -rf doc
-make doc-searchengine
+make doc-searchengine  SVNVER=${ICUREV}
 
 #FN=icu-r$(svnversion /src/icu/ | tr -d ' ')-$(bash /src/icu/icu4c/source/config.guess)-${1:RANDOM}
 tar cfpz /dist/${FN}-sdoc.tgz ./doc || exit 1


### PR DESCRIPTION
Fixes: https://github.com/unicode-org/icu-docker/issues/7

I verified that this is able to create a near-identical icu4c 62.1 package. Differences are:
- `.gitignore` was moved to the top level
- the bomlist file has contents in a different order (due to svn)

with this PR, `make dist` produces:

```
icu-r4a3ba8e-x86_64-pc-linux-gnu-Ubuntu-18.04-sdoc.tgz
icu-r4a3ba8e-x86_64-pc-linux-gnu-Ubuntu-18.04-src.d/icu4c-data-62_1-r4a3ba8e.zip
icu-r4a3ba8e-x86_64-pc-linux-gnu-Ubuntu-18.04-src.d/icu4c-docs-62_1-r4a3ba8e.zip
icu-r4a3ba8e-x86_64-pc-linux-gnu-Ubuntu-18.04-src.d/icu4c-src-62_1-r4a3ba8e.tgz
icu-r4a3ba8e-x86_64-pc-linux-gnu-Ubuntu-18.04-src.d/icu4c-src-62_1-r4a3ba8e.zip
icu-r4a3ba8eee9-x86_64-pc-linux-gnu-Fedora-28.tgz
icu-r4a3ba8eee9-x86_64-pc-linux-gnu-Fedora-28.tgz.md5
icu-r4a3ba8eee9-x86_64-pc-linux-gnu-Ubuntu-18.04.tgz
icu-r4a3ba8eee9-x86_64-pc-linux-gnu-Ubuntu-18.04.tgz.md5
```

… where the git hash https://github.com/unicode-org/icu/commit/4a3ba8eee90ea1414d4f7ee36563e6c9b28fda96  refers to the tag https://github.com/unicode-org/icu/releases/tag/release-62-1