### PR TITLE
bug: convert ' ' to '_' in NAME

### DIFF
--- a/src/bin/makedist.sh
+++ b/src/bin/makedist.sh
@@ -8,6 +8,7 @@ if [ -f /etc/os-release ];
 then
     . /etc/os-release
 fi
+NAME=$(echo "${NAME}" | tr " " "_")
 FN=icu-r${REV-$(svnversion /src/icu/ | tr -d ' ')}-$(bash /src/icu/icu4c/source/config.guess)-${NAME-${WHAT}}-${VERSION_ID-UNKNOWN}
 if [ ! -f config.status ];
 then

--- a/src/bin/makesdoc.sh
+++ b/src/bin/makesdoc.sh
@@ -15,6 +15,7 @@ if [ -f /etc/os-release ];
 then
     . /etc/os-release
 fi
+NAME=$(echo "${NAME}" | tr " " "_")
 FN=icu-r${REV-$(svnversion /src/icu/ | tr -d ' ')}-$(bash /src/icu/icu4c/source/config.guess)-${NAME-${WHAT}}-${VERSION_ID-UNKNOWN}
 
 rm -rf dist /dist/${FN}-src.d || true


### PR DESCRIPTION
- Alpine has a NAME of "Alpine Linux" in /etc/os-release

So `make dist-some DISTROS_SMALL=alpine` failed