### PR TITLE
make: Allow local overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # License & terms of use: http://www.unicode.org/copyright.html
 
 DIRS=tmp src tmp/.ccache dist
-
+DOCKER_COMPOSE=docker-compose
 ICU_REPO=http://source.icu-project.org/repos/icu/trunk
 BINPATH=/src/bin/
 DISTROS=$(shell cd dockerfiles;ls)
@@ -20,12 +20,12 @@ dirs:
 	chmod -R o+rX src
 
 dbuild: docker-compose.yml
-	docker-compose build
+	$(DOCKER_COMPOSE) build
 
 build-all: all
 	for distro in $(DISTROS); do \
 	  echo $$distro ; \
-	  ( docker-compose run $$distro bash $(BINPATH)/build.sh || exit 1); \
+	  ( $(DOCKER_COMPOSE) run $$distro bash $(BINPATH)/build.sh || exit 1); \
 	done
 	echo all OK
 
@@ -33,7 +33,7 @@ check-all: all
 	for distro in $(DISTROS); do \
 	  echo $$distro ; \
 	rm -f $$distro.fail ; \
-	  ( docker-compose run $$distro bash $(BINPATH)/check.sh || (>$$distro.fail; exit 1)) >&1 | tee $$distro.out; \
+	  ( $(DOCKER_COMPOSE) run $$distro bash $(BINPATH)/check.sh || (>$$distro.fail; exit 1)) >&1 | tee $$distro.out; \
 	done
 	echo all OK
 
@@ -41,21 +41,21 @@ check-some: all
 	for distro in $(DISTROS_SMALL); do \
 	  echo $$distro ; \
 	rm -f $$distro.fail ; \
-	  ( docker-compose run $$distro bash $(BINPATH)/check.sh || (>$$distro.fail; exit 1)) >&1 | tee $$distro.out; \
+	  ( $(DOCKER_COMPOSE) run $$distro bash $(BINPATH)/check.sh || (>$$distro.fail; exit 1)) >&1 | tee $$distro.out; \
 	done
 	echo all OK
 
 dist-all: all 
 	for distro in $(DISTROS); do \
 	  echo $$distro ; \
-	  ( docker-compose run $$distro env REV=$(REV) WHAT=$$distro $(BINPATH)/makedist.sh $$distro || exit 1); \
+	  ( $(DOCKER_COMPOSE) run $$distro env REV=$(REV) WHAT=$$distro $(BINPATH)/makedist.sh $$distro || exit 1); \
 	done
 	echo all OK
 
 dist-some: all 
 	for distro in $(DISTROS_SMALL); do \
 	  echo $$distro ; \
-	  ( docker-compose run $$distro env REV=$(REV) WHAT=$$distro $(BINPATH)/makedist.sh $$distro || exit 1); \
+	  ( $(DOCKER_COMPOSE) run $$distro env REV=$(REV) WHAT=$$distro $(BINPATH)/makedist.sh $$distro || exit 1); \
 	done
 	echo all OK
 
@@ -64,14 +64,14 @@ dist: sdist dist-some
 sdist: all 
 	for distro in $(firstword $(DISTROS_SMALL)); do \
 	  echo $$distro ; \
-	  ( docker-compose run $$distro env REV=$(REV) WHAT=$$distro $(BINPATH)/makesdoc.sh $$distro || exit 1); \
+	  ( $(DOCKER_COMPOSE) run $$distro env REV=$(REV) WHAT=$$distro $(BINPATH)/makesdoc.sh $$distro || exit 1); \
 	done
 	echo all OK
 
 perf-all: all 
 	for distro in $(DISTROS); do \
 	  echo $$distro ; \
-	  ( docker-compose run $$distro bash $(BINPATH)/perf.sh $$distro || exit 1); \
+	  ( $(DOCKER_COMPOSE) run $$distro bash $(BINPATH)/perf.sh $$distro || exit 1); \
 	done
 	echo all OK
 
@@ -79,8 +79,6 @@ perf-all: all
 
 pretest-run.pl:
 	wget http://git.savannah.gnu.org/cgit/pretest.git/plain/pretest-run.pl
-
-
 
 -include Makefile.local
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 This is a set of dockerfiles and a Makefile to develop with ICU (against Ubuntu, Fedora, anything else you can run from docker).
 It sets up `ccache` to share cached compiler output in `./tmp/.ccache` and expects an ICU source directory under `./src/icu`
 
+## Customization
+
+You can create a `Makefile.local` that can point to a different docker-compose.yaml:
+
+```
+# Makefile.local
+DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
+```
 
 ## Usage
 


### PR DESCRIPTION
Little change:

- add Makefile.local support
- document how to override the docker-compose file

Motivation: I use `local-docker-compose.yml` as follows so that I can use a reference-clone of ICU inside docker.

I suppose, similarly, I could mount `- /Users/srl/src/icu:/src/icu:ro` and just mount my whole main git worktree as readonly.

```
  volumes:
    - ./src:/src
    - ./dist:/dist
    - ./tmp/.ccache:/home/build/.ccache
    - /Users/srl/src/icu/.git/objects:/Users/srl/src/icu/.git/objects:ro
```