### PR TITLE
ICU-21480 Update ICU4C release instructions. Omit 'subversion'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,38 +18,38 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
 
 - install [Docker](http://docker.io)
 - bring in ICU source
-```
+  ```
   cd src
   git clone --branch master --depth 1 https://github.com/unicode-org/icu.git
   cd icu
   git lfs fetch
   git lfs checkout
   cd ../..
-```
+  ```
 - run tests
-```
+  ```
   make check-all
-```
+  ```
 - build binaries
-```
+  ```
   make dist
-```         
+  ```         
 - sort into dist/icu4c-*/*
 
   The files should include the version label such as "69rc" for the release candidate of ICU version 69. The general availability for that would be "69.1". 
-```
+  ```
   ./sort-out-dist.sh
   ls -l dist/icu4c-*
-```
+  ```
 - optional: Link `src/` to `/src` on your system
 
 This symlink will make error messages from inside the container usable on your local system, of the form: `Error in /src/icu/somefile.cpp`.
-```
+  ```
   sudo ln -sv `pwd`/{src,dist} /
-```
+  ```
 
 - Perform some command line builds to verify the release.
-```
+  ```
   $ docker-compose run ubuntu bash
   # This creates a temporary docker shell with a name such as 'build@59b67f6c5058:~'
   build@59b67f6c5058:~$ /src/icu/icu4c/source/configure
@@ -57,7 +57,7 @@ This symlink will make error messages from inside the container usable on your l
   build@59b67f6c5058:~$ make check  # To run all ICU4C tests
   ...
   build@59b67f6c5058:~$ exit  # To leave the docker shell
-```
+  ```
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
   ```
 - optional: Link `src/` to `/src` on your system
 
-This symlink will make error messages from inside the container usable on your local system, of the form: `Error in /src/icu/somefile.cpp`.
+  This symlink will make error messages from inside the container usable on your local system, of the form: `Error in /src/icu/somefile.cpp`.
   ```
   sudo ln -sv `pwd`/{src,dist} /
   ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
 ````
 - optional: symlink `src/` to `/src` on your system
 
-This will make error messages work
+This symlink will make error messages from inside the container usable on your local system, of the form: `Error in /src/icu/somefile.cpp`.
 ````
      sudo ln -sv `pwd`/{src,dist} /
 ````

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This symlink will make error messages from inside the container usable on your l
 - Perform some command line builds to verify the release.
 ```
     $ docker-compose run ubuntu bash
-    # This creates a temporary docker shell with a name such as 'build@671f33b0fe95:~'
+    # This creates a temporary docker shell with a name such as 'build@59b67f6c5058:~'
     build@59b67f6c5058:~$ /src/icu/icu4c/source/configure
     # This will show the ICU version number of the release just created.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This symlink will make error messages from inside the container usable on your l
   # This creates a temporary docker shell with a name such as 'build@59b67f6c5058:~'
   build@59b67f6c5058:~$ /src/icu/icu4c/source/configure
   # This will show the ICU version number of the release just created.
-   build@59b67f6c5058:~$ make check  # To run all ICU4C tests
+  build@59b67f6c5058:~$ make check  # To run all ICU4C tests
   ...
   build@59b67f6c5058:~$ exit  # To leave the docker shell
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
   ```
   make dist
   ```         
-- sort into dist/icu4c-*/*
+- sort into `dist/icu4c-*/*`
 
   The files should include the version label such as "69rc" for the release candidate of ICU version 69. The general availability for that would be "69.1". 
   ```

--- a/README.md
+++ b/README.md
@@ -18,37 +18,47 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
 
 - install [Docker](http://docker.io)
 - bring in ICU source
-
-     cd src
-     git clone --branch master --depth 1 https://github.com/unicode-org/icu.git
-     cd icu
-     git lfs fetch
-     git lfs checkout
-     cd ../..
-
+````
+    cd src
+    git clone --branch master --depth 1 https://github.com/unicode-org/icu.git
+    cd icu
+    git lfs fetch
+    git lfs checkout
+    cd ../..
+````
 - run tests
-
+````
      make check-all
-
+````
 - build binaries
+````
+    make dist
+````         
+- sort into dist/icu4c-*/*
 
-     make dist
-     # sort into dist/icu4c-66.1/*
+The files should include the version label such as "69rc" for the release candidate of ICU version 69. The general availability for that woud be "69.1". 
+````
      ./sort-out-dist.sh
      ls -l dist/icu4c-*
-
+````
 - optional: symlink `src/` to `/src` on your system
 
-this will make error messages work
-
+This will make error messages work
+````
      sudo ln -sv `pwd`/{src,dist} /
+````
 
-- do some command line builds
-
+- Perform some command line builds to verify the release.
 ```
     $ docker-compose run ubuntu bash
+    # This creates a temporary docker shell with a name such as 'build@671f33b0fe95:~'
     build@59b67f6c5058:~$ /src/icu/icu4c/source/configure
-    checking for ICU version numbers...
+    # This will show the ICU version number of the release just created.
+
+    build@59b67f6c5058:~$ make check  # To run all ICU4C tests
+    ...
+    build@59b67f6c5058:~$ exit  # To leave the docker shell
+    
 ```
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
 ````         
 - sort into dist/icu4c-*/*
 
-The files should include the version label such as "69rc" for the release candidate of ICU version 69. The general availability for that woud be "69.1". 
+  The files should include the version label such as "69rc" for the release candidate of ICU version 69. The general availability for that woud be "69.1". 
 ````
      ./sort-out-dist.sh
      ls -l dist/icu4c-*

--- a/README.md
+++ b/README.md
@@ -18,47 +18,45 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
 
 - install [Docker](http://docker.io)
 - bring in ICU source
-````
-    cd src
-    git clone --branch master --depth 1 https://github.com/unicode-org/icu.git
-    cd icu
-    git lfs fetch
-    git lfs checkout
-    cd ../..
-````
+```
+  cd src
+  git clone --branch master --depth 1 https://github.com/unicode-org/icu.git
+  cd icu
+  git lfs fetch
+  git lfs checkout
+  cd ../..
+```
 - run tests
-````
-     make check-all
-````
+```
+  make check-all
+```
 - build binaries
-````
-    make dist
-````         
+```
+  make dist
+```         
 - sort into dist/icu4c-*/*
 
   The files should include the version label such as "69rc" for the release candidate of ICU version 69. The general availability for that woud be "69.1". 
-````
-     ./sort-out-dist.sh
-     ls -l dist/icu4c-*
-````
-- optional: symlink `src/` to `/src` on your system
+```
+  ./sort-out-dist.sh
+  ls -l dist/icu4c-*
+```
+- optional: Link `src/` to `/src` on your system
 
 This symlink will make error messages from inside the container usable on your local system, of the form: `Error in /src/icu/somefile.cpp`.
-````
-     sudo ln -sv `pwd`/{src,dist} /
-````
+```
+  sudo ln -sv `pwd`/{src,dist} /
+```
 
 - Perform some command line builds to verify the release.
 ```
-    $ docker-compose run ubuntu bash
-    # This creates a temporary docker shell with a name such as 'build@59b67f6c5058:~'
-    build@59b67f6c5058:~$ /src/icu/icu4c/source/configure
-    # This will show the ICU version number of the release just created.
-
-    build@59b67f6c5058:~$ make check  # To run all ICU4C tests
-    ...
-    build@59b67f6c5058:~$ exit  # To leave the docker shell
-    
+  $ docker-compose run ubuntu bash
+  # This creates a temporary docker shell with a name such as 'build@59b67f6c5058:~'
+  build@59b67f6c5058:~$ /src/icu/icu4c/source/configure
+  # This will show the ICU version number of the release just created.
+   build@59b67f6c5058:~$ make check  # To run all ICU4C tests
+  ...
+  build@59b67f6c5058:~$ exit  # To leave the docker shell
 ```
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
 ```         
 - sort into dist/icu4c-*/*
 
-  The files should include the version label such as "69rc" for the release candidate of ICU version 69. The general availability for that woud be "69.1". 
+  The files should include the version label such as "69rc" for the release candidate of ICU version 69. The general availability for that would be "69.1". 
 ```
   ./sort-out-dist.sh
   ls -l dist/icu4c-*

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -11,7 +11,7 @@ RUN useradd -c "Build user" -d $HOME -m build
 
 # sanity and safety
 RUN apt-get -q -y update && apt-get -q -y upgrade
-RUN apt-get -q -y install make git subversion python ccache valgrind doxygen zip curl wget rsync
+RUN apt-get -q -y install make git python ccache valgrind doxygen zip curl wget rsync
 RUN apt-get -q -y install g++
 RUN apt-get -q -y install git-lfs
 RUN mkdir /src /dist

--- a/dockerfiles/ubuntuclang/Dockerfile
+++ b/dockerfiles/ubuntuclang/Dockerfile
@@ -10,7 +10,7 @@ RUN useradd -c "Build user" -d $HOME -m build
 
 # sanity and safety
 RUN apt-get -q -y update && apt-get -q -y upgrade
-RUN apt-get -q -y install make git subversion python ccache valgrind doxygen zip curl wget
+RUN apt-get -q -y install make git python ccache valgrind doxygen zip curl wget
 RUN apt-get -q -y install clang
 RUN mkdir /src /dist
 VOLUME /src


### PR DESCRIPTION
This fixes formatting and clarifies some instructions.

Removing references to 'subversion' simplifies this and may avoid errors.