### PR TITLE
ICU-21508 Rename 'master' to 'main' in instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
 - bring in ICU source
   ```
   cd src
-  git clone --branch master --depth 1 https://github.com/unicode-org/icu.git
+  git clone --branch main --depth 1 https://github.com/unicode-org/icu.git
   cd icu
   git lfs fetch
   git lfs checkout


### PR DESCRIPTION
The icu-docker counterpart of https://github.com/unicode-org/icu/pull/1664