### PR TITLE
Fix docker to make ICU4C distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ dist: sdist dist-some
 sdist: all 
 	for distro in $(firstword $(DISTROS_SMALL)); do \
 	  echo $$distro ; \
-	  ( $(DOCKER_COMPOSE) run $$distro env REV=$(REV) WHAT=$$distro $(BINPATH)/makesdoc.sh $$distro || exit 1); \
+	  ( $(DOCKER_COMPOSE) run $$distro env REV=$(REV) WHAT=$$distro $(BINPATH)makesdoc.sh $$distro || exit 1); \
 	done
 	echo all OK
 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,67 @@
-# icu-dev
+# ICU development with Docker
 
-> ICU development inside Docker
+This repository creates ICU4C releases using Docker for multiple Linux versions. The binary files results may be added to [ICU releases](https://github.com/unicode-org/icu/releases) for public distribution, especially for the release candidates ("72 RC") and fully released versions (e.g., "72.1").
 
-This is a set of dockerfiles and a Makefile to develop with ICU (against Ubuntu, Fedora, anything else you can run from docker).
-It sets up `ccache` to share cached compiler output in `./tmp/.ccache` and expects an ICU source directory under `./src/icu`
+TO use this repository you will need:
 
-## Customization
+* Access to ICU in the Github repository
+* A branch within that repository
+* Docker installed and configured
 
-You can create a `Makefile.local` that can point to a different docker-compose.yaml:
+This repository contains:
+* A set of docker files for the various Linux versions
+* Makefile for driving the compiling, checking, and building of these versions
+* Some utility scripts to finalize release files for uploading to public directories.
 
-```
-# Makefile.local
-DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
-```
+ICU-docker runs a *docker-compose* command for each of the Linux targets. The outputs are created in a subdirectory `./dist`.
 
-## Usage
+Each *docker-compose* execution sets up `ccache` to share cached compiler output in `./tmp/.ccache` and expects an ICU source directory under `./src/icu`
 
-- install [Docker](http://docker.io)
-- bring in ICU source
+## Build the distributions
+
+The following steps create binary files for each docker file in `./dockerfiles` and also Fedora and Ubuntu binary files.
+
+- Install [Docker](http://docker.io)
+- Copy the code for a given branch of [ICU source in github](https://github.com/unicode-org/icu).
+
   ```
   cd src
-  git clone --branch main --depth 1 https://github.com/unicode-org/icu.git
+  export BRANCH=maint/maint-72  # Set this up to use the Githum version you need.
+
+  git clone --branch $BRANCH --depth 1 https://github.com/unicode-org/icu.git
   cd icu
-  git lfs fetch
-  git lfs checkout
+  git lfs fetch; git lfs checkout
   cd ../..
   ```
-- run tests
+- Compile and Run tests to verify the ICU4C version
   ```
   make check-all
   ```
-- build binaries
+- Build binaries, data, and source as .zip and .tgz files in the ./dist directory
   ```
   make dist
-  ```         
-- sort into `dist/icu4c-*/*`
+  ```       
+  Note that some filenames in ./dist/ will need to be adjusted so be sure to rename. Use the script sort-out-dist.sh, and then manually adjust as needed to match the names as in previous releases.
+  
+- Sort and rename files into `dist/icu4c-*/*`
 
-  The files should include the version label such as "69rc" for the release candidate of ICU version 69. The general availability for that would be "69.1". 
+Each binary needs to include the version label, e.g., "69rc" for the release candidate of ICU version 69. The general availability for that would be "69.1". 
   ```
   ./sort-out-dist.sh
   ls -l dist/icu4c-*
   ```
-- optional: Link `src/` to `/src` on your system
+  **Hint:** Check the names of files in a previous release such as [Release ICU 72.1](https://github.com/unicode-org/icu/releases/tag/release-72-1) in order to check if the renaming was successful. If not, perform manual renaming as needed.
 
-  This symlink will make error messages from inside the container usable on your local system, of the form: `Error in /src/icu/somefile.cpp`.
+### Optional: Link `src/` to `/src` on your system
+
+  This symlink will make give access to the error messages generated inside each docker container. For example: `Error in /src/icu/somefile.cpp`.
   ```
   sudo ln -sv `pwd`/{src,dist} /
   ```
 
-- Perform some command line builds to verify the release.
+## Verify that the distributions work
+
+Perform some command line builds to verify the release. Use `docker-compose run` with each of the releases to check the build. Do this for each of the target Linux versions in `./dockerfiles`.
   ```
   $ docker-compose run ubuntu bash
   # This creates a temporary docker shell with a name such as 'build@59b67f6c5058:~'
@@ -58,6 +71,16 @@ DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
   ...
   build@59b67f6c5058:~$ exit  # To leave the docker shell
   ```
+
+## Customization
+
+If desired, you can create a `Makefile.local` that can point to a different
+docker-compose.yaml:
+
+```
+# Makefile.local
+DOCKER_COMPOSE=docker-compose -f local-docker-compose.yml
+```
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This repository creates ICU4C releases using Docker for multiple Linux versions. The binary files results may be added to [ICU releases](https://github.com/unicode-org/icu/releases) for public distribution, especially for the release candidates ("72 RC") and fully released versions (e.g., "72.1").
 
-TO use this repository you will need:
+To use this repository you will need:
 
-* Access to ICU in the Github repository
-* A branch within that repository
+* Access to the [ICU repository in Github](https://www.github.com/unicode-org/icu)
+* Know the branch / tag of interest within that repository
 * Docker installed and configured
 
 This repository contains:
@@ -26,7 +26,7 @@ The following steps create binary files for each docker file in `./dockerfiles` 
 
   ```
   cd src
-  export BRANCH=maint/maint-72  # Set this up to use the Githum version you need.
+  export BRANCH=maint/maint-72  # Set this up to use the git ref (branch / Github release tag) you need.
 
   git clone --branch $BRANCH --depth 1 https://github.com/unicode-org/icu.git
   cd icu
@@ -54,7 +54,7 @@ Each binary needs to include the version label, e.g., "69rc" for the release can
 
 ### Optional: Link `src/` to `/src` on your system
 
-  This symlink will make give access to the error messages generated inside each docker container. For example: `Error in /src/icu/somefile.cpp`.
+  This symlink will give access to the error messages generated inside each docker container. For example: `Error in /src/icu/somefile.cpp`.
   ```
   sudo ln -sv `pwd`/{src,dist} /
   ```

--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 USER root
 ENV HOME /home/build
 
-RUN apk --update add gcc make python g++ ccache valgrind doxygen tar zip curl wget git bash
+RUN apk --update add gcc make python3 g++ ccache valgrind doxygen tar zip curl wget git bash
 RUN addgroup build && adduser -g "Build user" -h $HOME -S -G build -D -s /bin/sh build
 
 RUN mkdir /src /dist
@@ -12,4 +12,4 @@ VOLUME /dist
 VOLUME /home/build
 WORKDIR /home/build
 USER build
-
+RUN git config --global --add safe.directory /src/icu

--- a/dockerfiles/fedora/Dockerfile
+++ b/dockerfiles/fedora/Dockerfile
@@ -9,7 +9,7 @@ ENV HOME /home/build
 RUN useradd -c "Build user" -d $HOME -m build
 #ENV RPMOPTZ --setopt=deltarpm=false
 # sanity and safety
-RUN dnf -q -y upgrade $RPMOPTZ && dnf -q -y install make git subversion python gcc-c++ ccache valgrind doxygen tar zip curl wget $RPMOPTZ
+RUN dnf -q -y upgrade $RPMOPTZ && dnf -q -y install make git subversion python3 gcc-c++ ccache valgrind doxygen tar zip curl wget $RPMOPTZ
 #extra
 # editing
 #RUN apt-get -q -y install emacs24-nox
@@ -19,3 +19,4 @@ VOLUME /dist
 VOLUME /home/build
 WORKDIR /home/build
 USER build
+RUN git config --global --add safe.directory /src/icu

--- a/dockerfiles/gcc/Dockerfile
+++ b/dockerfiles/gcc/Dockerfile
@@ -24,3 +24,4 @@ WORKDIR /home/build
 # ENV LD_LIBRARY_PATH /usr/local/lib
 
 USER build
+RUN git config --global --add safe.directory /src/icu

--- a/dockerfiles/gcc/Dockerfile
+++ b/dockerfiles/gcc/Dockerfile
@@ -17,6 +17,7 @@ VOLUME /src
 VOLUME /dist
 VOLUME /home/build
 WORKDIR /home/build
+
 # setup ccache
 # RUN for comp in g++ gcc ld; do ln -sv `which ccache` /usr/local/bin/$comp; done
 # icu-dev might get strange…

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -11,7 +11,7 @@ RUN useradd -c "Build user" -d $HOME -m build
 
 # sanity and safety
 RUN apt-get -q -y update && apt-get -q -y upgrade
-RUN apt-get -q -y install make git python ccache valgrind doxygen zip curl wget rsync
+RUN apt-get -q -y install make git python3 ccache valgrind doxygen zip curl wget rsync
 RUN apt-get -q -y install g++
 RUN apt-get -q -y install git-lfs
 RUN mkdir /src /dist
@@ -25,6 +25,7 @@ RUN for comp in g++ gcc ld; do ln -sv `which ccache` /usr/local/bin/$comp; done
 RUN apt-get -q -y remove libicu-dev
 ENV LD_LIBRARY_PATH /usr/local/lib
 
+RUN git config --global --add safe.directory /src/icu
 USER build
 RUN git config --global --add safe.directory /src/icu
 

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -25,7 +25,6 @@ RUN for comp in g++ gcc ld; do ln -sv `which ccache` /usr/local/bin/$comp; done
 RUN apt-get -q -y remove libicu-dev
 ENV LD_LIBRARY_PATH /usr/local/lib
 
-RUN git config --global --add safe.directory /src/icu
 USER build
 RUN git config --global --add safe.directory /src/icu
 

--- a/dockerfiles/ubuntu32/Dockerfile
+++ b/dockerfiles/ubuntu32/Dockerfile
@@ -25,3 +25,4 @@ RUN apt-get -q -y remove libicu-dev
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 USER build
+RUN git config --global --add safe.directory /src/icu

--- a/dockerfiles/ubuntuclang/Dockerfile
+++ b/dockerfiles/ubuntuclang/Dockerfile
@@ -10,7 +10,7 @@ RUN useradd -c "Build user" -d $HOME -m build
 
 # sanity and safety
 RUN apt-get -q -y update && apt-get -q -y upgrade
-RUN apt-get -q -y install make git python ccache valgrind doxygen zip curl wget
+RUN apt-get -q -y install make git python3 ccache valgrind doxygen zip curl wget
 RUN apt-get -q -y install clang
 RUN mkdir /src /dist
 VOLUME /src
@@ -24,3 +24,4 @@ RUN apt-get -q -y remove libicu-dev
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 USER build
+RUN git config --global --add safe.directory /src/icu

--- a/dockerfiles/ubuntuclang/Dockerfile
+++ b/dockerfiles/ubuntuclang/Dockerfile
@@ -12,6 +12,8 @@ RUN useradd -c "Build user" -d $HOME -m build
 RUN apt-get -q -y update && apt-get -q -y upgrade
 RUN apt-get -q -y install make git python3 ccache valgrind doxygen zip curl wget
 RUN apt-get -q -y install clang
+RUN apt-get update --fix-missing
+
 RUN mkdir /src /dist
 VOLUME /src
 VOLUME /dist

--- a/sort-out-dist.sh
+++ b/sort-out-dist.sh
@@ -10,7 +10,6 @@ STUFF=$(find icu-* -type f \( -name '*.zip' -o -name '*.tgz' \))
 trymove()
 {
     base2=$(basename $1)
-    # echo "@@@@@@ move " $1 " to" $3
     if [ -f ${2}/${3} ];
     then
         echo "# exists: ${2}/${3} (not copying $base2)"
@@ -43,7 +42,6 @@ do
     # echo $base
     case $base in
         *-sdoc.tgz)
-            # echo "source doc" $base
             trymove ${file} ${dir} SOURCEDOC-${prefix}-SOURCEDOC.tgz
             ;;
         *-Fedora*.tgz|*-Ubuntu-*.tgz)
@@ -54,14 +52,13 @@ do
                 *) ;;
             esac
             sys=$(basename $file .tgz | cut -d - -f9,10 | tr -d - )
-            # echo "linux bin" $base "=" $arch "sys" $sys
             outname=${prefix}-${sys}-${arch}.tgz
             trymove ${file} ${dir} ${outname} 
             ;;
 
 
         ${mainver}-docs.zip|${mainver}-src.tgz|${mainver}-src.zip|${mainver}-data.zip|${mainver}-data-bin-b.zip|${mainver}-data-bin-l.zip)
-          # Only if the version is not the same as the
+          # Only if the version is not the same as the .zip file's name
           if [ "$mainver" != "$prefix" ]; 
           then
             # Has the name with the final release version. Change to the actual release name

--- a/sort-out-dist.sh
+++ b/sort-out-dist.sh
@@ -25,8 +25,10 @@ do
     #echo "# ${file}"
     base=$(basename $file)
     # rver is '66-1' or '66-rc'
-    mainver="icu4c-"$(echo $file | grep "^icu-rrelease-[0-9][0-9]-[0-9rc]" | cut -d- -f3)"_1"
     rver=$(echo $file | grep "^icu-rrelease-[0-9][0-9]-[0-9rc]" | cut -d- -f3-4)
+
+    # The version of the file
+    mainver="icu4c-"$(echo $file | grep "^icu-rrelease-[0-9][0-9]-[0-9rc]" | cut -d- -f3)"_1"
     if [ "${rver}" = "" ];
     then
         echo "# ${file} - could not extract release version."
@@ -45,7 +47,7 @@ do
             trymove ${file} ${dir} SOURCEDOC-${prefix}-SOURCEDOC.tgz
             ;;
         *-Fedora*.tgz|*-Ubuntu-*.tgz)
-            # icu-rrelease-66-1-x86_64-pc-linux-gnu-Ubuntu-18.04.tgz
+            # e.g., icu-rrelease-66-1-x86_64-pc-linux-gnu-Ubuntu-18.04.tgz
             arch=$(basename $file | cut -d - -f5)
             case $arch in
                 x86_64) arch="x64" ;;
@@ -59,9 +61,10 @@ do
 
 
         ${mainver}-docs.zip|${mainver}-src.tgz|${mainver}-src.zip|${mainver}-data.zip|${mainver}-data-bin-b.zip|${mainver}-data-bin-l.zip)
+          # Only if the version is not the same as the
           if [ "$mainver" != "$prefix" ]; 
           then
-            # Has the name with the release version. Change to the actual release name
+            # Has the name with the final release version. Change to the actual release name
             newname=${base/$mainver/$prefix}
             trymove ${file} ${dir} ${newname}
           fi

--- a/sort-out-dist.sh
+++ b/sort-out-dist.sh
@@ -24,7 +24,7 @@ do
     #echo "# ${file}"
     base=$(basename $file)
     # rver is '66-1'
-    rver=$(echo $file | grep "^icu-rrelease-[0-9][0-9]-[0-9]" | cut -d- -f3-4)
+    rver=$(echo $file | grep "^icu-rrelease-[0-9][0-9]-[0-9rc]" | cut -d- -f3-4)
     if [ "${rver}" = "" ];
     then
         echo "# ${file} - could not extract release version."
@@ -38,7 +38,7 @@ do
     # echo $base
     case $base in
         *-sdoc.tgz)
-            # echo "soruce doc" $base
+            # echo "source doc" $base
             trymove ${file} ${dir} SOURCEDOC-${prefix}-SOURCEDOC.tgz
             ;;
         *-Fedora-*.tgz|*-Ubuntu-*.tgz)

--- a/sort-out-dist.sh
+++ b/sort-out-dist.sh
@@ -10,6 +10,7 @@ STUFF=$(find icu-* -type f \( -name '*.zip' -o -name '*.tgz' \))
 trymove()
 {
     base2=$(basename $1)
+    # echo "@@@@@@ move " $1 " to" $3
     if [ -f ${2}/${3} ];
     then
         echo "# exists: ${2}/${3} (not copying $base2)"
@@ -23,7 +24,8 @@ for file in ${STUFF};
 do
     #echo "# ${file}"
     base=$(basename $file)
-    # rver is '66-1'
+    # rver is '66-1' or '66-rc'
+    mainver="icu4c-"$(echo $file | grep "^icu-rrelease-[0-9][0-9]-[0-9rc]" | cut -d- -f3)"_1"
     rver=$(echo $file | grep "^icu-rrelease-[0-9][0-9]-[0-9rc]" | cut -d- -f3-4)
     if [ "${rver}" = "" ];
     then
@@ -35,13 +37,14 @@ do
     dir=icu4c-$(echo $rver | tr - .)
     mkdir -pv ./${dir}/
 
+    
     # echo $base
     case $base in
         *-sdoc.tgz)
             # echo "source doc" $base
             trymove ${file} ${dir} SOURCEDOC-${prefix}-SOURCEDOC.tgz
             ;;
-        *-Fedora-*.tgz|*-Ubuntu-*.tgz)
+        *-Fedora*.tgz|*-Ubuntu-*.tgz)
             # icu-rrelease-66-1-x86_64-pc-linux-gnu-Ubuntu-18.04.tgz
             arch=$(basename $file | cut -d - -f5)
             case $arch in
@@ -53,10 +56,22 @@ do
             outname=${prefix}-${sys}-${arch}.tgz
             trymove ${file} ${dir} ${outname} 
             ;;
-        ${prefix}-docs.zip|${prefix}-src.tgz|${prefix}-src.zip|${prefix}-data.zip)
-            # already has the right name
+
+
+        ${mainver}-docs.zip|${mainver}-src.tgz|${mainver}-src.zip|${mainver}-data.zip|${mainver}-data-bin-b.zip|${mainver}-data-bin-l.zip)
+          if [ "$mainver" != "$prefix" ]; 
+          then
+            # Has the name with the release version. Change to the actual release name
+            newname=${base/$mainver/$prefix}
+            trymove ${file} ${dir} ${newname}
+          fi
+          ;;
+
+        ${prefix}-docs.zip|${prefix}-src.tgz|${prefix}-src.zip|${prefix}-data.zip|${prefix}-data-bin-b.zip|${prefix}-data-bin-l.zip)
+            # already has the right name so move it to the output area
             trymove ${file} ${dir} ${base}
             ;;
+
         icu4c-${uver}-*)
             # ignore anything else with uver
             echo "# Ignored: ${base}"

--- a/src/bin/icu-configure.sh
+++ b/src/bin/icu-configure.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # © 2016 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html
+git config --global --add safe.directory /src/icu
 
 . /src/bin/icu-dev.sh
 exec ${SHELL} /src/icu/icu4c/source/configure $*

--- a/src/bin/makesdoc.sh
+++ b/src/bin/makesdoc.sh
@@ -26,6 +26,8 @@ mv -v dist /dist/${FN}-src.d
 rm -rf doc
 make doc-searchengine
 
+git config --global --add safe.directory /src/icu
+
 #FN=icu-r$(svnversion /src/icu/ | tr -d ' ')-$(bash /src/icu/icu4c/source/config.guess)-${1:RANDOM}
 tar cfpz /dist/${FN}-sdoc.tgz ./doc || exit 1
 #cd /dist


### PR DESCRIPTION
Docker now requires an additional git command for security. In addition, the scripts should explicitly reference python3.

Finally, this PR improves the sort script that creates standard filenames of binary release files.